### PR TITLE
Potential fix for code scanning alert no. 1: Insecure randomness

### DIFF
--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1,4 +1,5 @@
 const fs = require('node:fs')
+const { randomBytes } = require('node:crypto')
 const { expect, it, describe } = require('@jest/globals')
 const tmp = require('tmp')
 
@@ -31,7 +32,7 @@ if (repoPath) {
   describe('storage', () => {
     it('can upload and download a file', async () => {
       const tempFile = tmp.fileSync()
-      const theSecretMessage = Math.random().toString(36)
+      const theSecretMessage = randomBytes(16).toString('hex')
       fs.writeFileSync(tempFile.name, theSecretMessage)
       await uploadFile(tempFile.name, repoPath, 'committed from test')
       fs.unlinkSync(tempFile.name)


### PR DESCRIPTION
Potential fix for [https://github.com/Kong/gh-storage/security/code-scanning/1](https://github.com/Kong/gh-storage/security/code-scanning/1)

Use Node.js crypto-secure randomness for generating the test message instead of `Math.random()`.  
Best fix here: import `randomBytes` from `node:crypto` and create the message from random bytes (for example, hex encoding). This preserves existing functionality (a random string written/read back) while removing insecure randomness.

In `tests/repo.test.js`:
- Add `const { randomBytes } = require('node:crypto')` near existing imports.
- Replace line 34 `Math.random().toString(36)` with a `randomBytes(...).toString(...)` expression.

No other logic changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
